### PR TITLE
fix: ignore stale GOOGLE_APPLICATION_CREDENTIALS in prod/staging to r…

### DIFF
--- a/src/gcp_session_manager.py
+++ b/src/gcp_session_manager.py
@@ -77,7 +77,6 @@ class GCPEphemeralSessionManager:
 
         if self.use_firestore:
             try:
-                import os
                 from google.oauth2 import service_account
 
                 # 1️⃣ Attempt to use Application Default Credentials first. In Cloud Run this


### PR DESCRIPTION
…estore Firestore default creds\n\nIf the env var points to a non-existent file, Firestore init failed. We now strip it in non-dev environments so Cloud Run’s runtime SA is used automatically.