### PR TITLE
feat: log Speech V2 streaming errors without killing thread\n\nEmit S…

### DIFF
--- a/src/speech_agent.py
+++ b/src/speech_agent.py
@@ -527,6 +527,15 @@ class ProductionSTTServiceV2:
                 if not self._is_recording:
                     break
                     
+                # NEW 🔴 Log API-level errors early and continue
+                if hasattr(response, 'error') and response.error.code != 0:
+                    print(
+                        f"❌ STREAMING_ERROR: code={response.error.code} msg={response.error.message} details={response.error.details}"
+                    )
+                    # Raising here would unwind the thread and force a restart; instead, let
+                    # upper-level timeout logic handle restarts so we can log many samples.
+                    continue
+
                 # Process the streaming response
                 self._handle_streaming_response(response)
                 


### PR DESCRIPTION
…TREAMING_ERROR lines with gRPC code, message and details so we can see root-cause in Cloud Run logs while keeping session alive.